### PR TITLE
fix(reactive): correct `vite.config`

### DIFF
--- a/.changeset/silver-geese-carry.md
+++ b/.changeset/silver-geese-carry.md
@@ -1,0 +1,10 @@
+---
+"@quick-threejs/reactive": patch
+---
+
+# Logs
+
+## fix(reactive): correct `vite.config`
+
+- Mark dependencies as `external` resources
+- Set `threads` & `rxjs` as peer-dependencies

--- a/packages/reactive/package.json
+++ b/packages/reactive/package.json
@@ -52,6 +52,8 @@
 		"stats.js": "^0.17.0"
 	},
 	"peerDependencies": {
+		"rxjs": "^7.8.1",
+		"threads": "^1.7.0",
 		"three": "^0.169.0",
 		"stats.js": "^0.17.0"
 	},

--- a/packages/reactive/src/core/app/app.module.ts
+++ b/packages/reactive/src/core/app/app.module.ts
@@ -41,7 +41,7 @@ export class AppModule
 		super();
 		this._initProxyEvents();
 
-		if (typeof self !== "undefined")
+		if (typeof self?.addEventListener === "function")
 			self.addEventListener("message", this._onMessage.bind(this));
 	}
 

--- a/packages/reactive/vite.config.ts
+++ b/packages/reactive/vite.config.ts
@@ -7,21 +7,32 @@ export default defineConfig({
 	...configs.vite,
 	build: {
 		lib: {
-			entry: resolve(__dirname, "src/main.ts"),
-			name: "QuickThreeUtils",
-			fileName: "main"
+			entry: {
+				main: resolve(__dirname, "src/main.ts"),
+				worker: resolve(__dirname, "src/main.worker.ts")
+			},
+			name: "QuickThreeReactive"
 		},
 		rollupOptions: {
-			external: ["three", "rxjs", "threads"],
+			external: [
+				"@quick-threejs/utils",
+				"rxjs",
+				"threads",
+				"three",
+				"stats.js"
+			],
 			output: {
 				globals: {
-					three: "THREE",
+					"@quick-threejs/utils": "QuickThreeUtils",
 					rxjs: "rxjs",
-					threads: "threads"
+					threads: "Threads",
+					three: "THREE",
+					"stats.js": "Stats"
 				}
 			}
 		}
 	},
+
 	resolve: {
 		alias: {
 			"@/": resolve(__dirname, "src/")

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2744,8 +2744,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.5.66:
-    resolution: {integrity: sha512-pI2QF6+i+zjPbqRzJwkMvtvkdI7MjVbSh2g8dlMguDJIXEPw+kwasS1Jl+YGPEBfGVxsVgGUratAKymPdPo2vQ==}
+  electron-to-chromium@1.5.67:
+    resolution: {integrity: sha512-nz88NNBsD7kQSAGGJyp8hS6xSPtWwqNogA0mjtc2nUYeEf3nURK9qpV18TuBdDmEDgVWotS8Wkzf+V52dSQ/LQ==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -7885,7 +7885,7 @@ snapshots:
   browserslist@4.24.2:
     dependencies:
       caniuse-lite: 1.0.30001684
-      electron-to-chromium: 1.5.66
+      electron-to-chromium: 1.5.67
       node-releases: 2.0.18
       update-browserslist-db: 1.1.1(browserslist@4.24.2)
 
@@ -8188,7 +8188,7 @@ snapshots:
     dependencies:
       jake: 10.9.2
 
-  electron-to-chromium@1.5.66: {}
+  electron-to-chromium@1.5.67: {}
 
   emittery@0.13.1: {}
 


### PR DESCRIPTION
# Summary

- Mark dependencies as `external` resources
- Set `threads` & `rxjs` as peer-dependencies


