### PR TITLE
chore(utils): bumps version to `0.1.16`

### DIFF
--- a/.changeset/proud-tables-cross.md
+++ b/.changeset/proud-tables-cross.md
@@ -1,0 +1,5 @@
+---
+"@quick-threejs/utils": patch
+---
+
+# chore(utils): bumps version to `0.1.16`


### PR DESCRIPTION
# Summary

---
