### PR TITLE
fix(ci): scope release build to publishable packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm whoami
 
-      - name: Build packages
-        run: pnpm build
+      - name: Build publishable packages
+        run: pnpm build:packages
 
       - name: Create Release Pull Request & Release
         uses: changesets/action@v1

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 	"scripts": {
 		"dev": "turbo dev",
 		"build": "turbo build",
+		"build:packages": "turbo build --filter=@quick-threejs/*",
 		"test": "turbo test",
 		"test:e2e": "turbo test:e2e",
 		"lint": "eslint . && turbo lint",


### PR DESCRIPTION
## Summary

- Fix the release workflow build failure caused by running `pnpm build` on sample apps (`with-legacy`, etc.).
- Add `build:packages` script that runs `turbo build --filter=@quick-threejs/*` and use it in the Releases workflow.

## Context

After #425, the release job failed at the new build step because `with-legacy` could not resolve `@quick-threejs/legacy` during `tsc` ([run #126](https://github.com/Neosoulink/quick-threejs/actions/runs/27837406563/job/82392713401)). Samples are not published and should not be built during release.

## Test plan

- [ ] Merge to `master`
- [ ] Re-run Releases workflow
- [ ] Confirm `build:packages` succeeds and npm publish completes for `@quick-threejs/reactive@0.1.52` and `@quick-threejs/worker@0.1.21`


Made with [Cursor](https://cursor.com)